### PR TITLE
Reject promise if no files match or glob error

### DIFF
--- a/src/markdown-processor.js
+++ b/src/markdown-processor.js
@@ -11,8 +11,11 @@ const processFile = (parser, file) => es.map((data, cb) => cb(null, parser(file,
 export function processFiles(filepath, parser=defaultParser) {
     const defer = Q.defer();
 
-    glob(filepath, {}, (er, files) => {
-        const streams = files.map(file => 
+    glob(filepath, {}, (err, files) => {
+        if(err || !files.length) {
+            return defer.reject(err ? err : { error: 'No files match' });
+        }
+        const streams = files.map(file =>
             createReadStream(file)
                 .pipe(processFile(parser, file)));
 
@@ -23,5 +26,3 @@ export function processFiles(filepath, parser=defaultParser) {
 
     return defer.promise;
 }
-
-


### PR DESCRIPTION
If you provide `processFiles` with a glob that returns zero files, the promise will never be fulfilled.

This patch rejects the promise if `glob` calls back with a truthy error value or an empty `files` array. 

![giphy 2](https://cloud.githubusercontent.com/assets/1307267/11733064/f11d7686-9f5e-11e5-88e8-34526c26ec12.gif)
